### PR TITLE
metrics_module is configured in the pushy_common app

### DIFF
--- a/src/pushy_metrics.erl
+++ b/src/pushy_metrics.erl
@@ -69,7 +69,7 @@ label(BadPrefix, Fun) ->
 %% Send a metric using the metrics module from application config or
 %% do nothing.
 send(Name, Value, Type) ->
-    case application:get_env(pushy, metrics_module) of
+    case application:get_env(pushy_common, metrics_module) of
         undefined -> ok;
         {ok, Mod} -> Mod:notify(Name, Value, Type)
     end,


### PR DESCRIPTION
metrics_module is now configured in the pushy_common namespace so it can be used by both push and pushysim
