### PR TITLE
Ma/oc 5335

### DIFF
--- a/src/pushy_client_config.erl
+++ b/src/pushy_client_config.erl
@@ -72,7 +72,7 @@ extract_plain_session_key(EJson) ->
 extract_enc_session_key(PrivateKey, EJson) ->
     EncodedSessionKey = ej:get({"encoded_session_key", "key"}, EJson),
     SessionMethod = pushy_messaging:method_to_atom(ej:get({"encoded_session_key", "method"}, EJson)),
-    SessionKey = public_key:decrypt_private(PrivateKey, base64:decode(EncodedSessionKey)),
+    SessionKey = public_key:decrypt_private(base64:decode(EncodedSessionKey), PrivateKey),
     {SessionMethod, SessionKey}.
 
 


### PR DESCRIPTION
Fix pushy common to handle both encrypted and unencrypted session keys. 
